### PR TITLE
Add ability to disable default metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The primary goals of this library are to:
 import { USE } from 'node-key-metrics'
 
 // Create an instance of USE with the desired configuration
+// The DefaultMetric can be either collected or disabled based on the value of the collectDefaultMetrics parameter. By default disabled.
 const useMetrics = new USE({
   saturationName: 'saturation',
   saturationHelp: 'saturation metric help text',
@@ -55,6 +56,7 @@ const useMetrics = new USE({
   utilizationName: 'utilization',
   utilizationHelp: 'utilization metric help text',
   utilizationLabels: ['label3', 'label4'],
+  collectDefaultMetrics: true,
 })
 
 // Increment the error counter

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Downloads][downloads-img]][downloads-url]
 [![Issues][issues-img]][issues-url]
 
-## A simple, lightweight metrics library that provides an interface for instrumenting Node.js applications with Prometheus.
+## A simple lightweight metrics library that provides an interface for instrumenting Node.js applications with Prometheus.
 
 ## Motivation
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "typescript": "^4.2.4"
   },
   "engines": {
-    "node": ">=18.0"
+    "node": ">=16.0"
   },
   "files": [
     "lib/**/*"

--- a/src/frameworks/FourGoldenSignals.ts
+++ b/src/frameworks/FourGoldenSignals.ts
@@ -12,6 +12,7 @@ type Props = {
   saturationName: string
   saturationHelp: string
   saturationLabels: string[]
+  collectDefaultMetrics?: boolean
 }
 
 class FourGoldenSignals extends Base<Props> {
@@ -43,7 +44,10 @@ class FourGoldenSignals extends Base<Props> {
     this.saturationLabels = params.saturationLabels
 
     this.validate(params)
-    defaultMetrics()
+
+    if (params.collectDefaultMetrics) {
+      defaultMetrics()
+    }
 
     this.errors = counter({
       name: 'errors_total',
@@ -54,7 +58,7 @@ class FourGoldenSignals extends Base<Props> {
     this.latency = histogram({
       name: this.latencyName,
       help: this.latencyHelp,
-      labelNames: this.latencyLabels,
+      labelNames: this.latencyLabels
     })
 
     this.saturation = gauge({
@@ -80,7 +84,8 @@ class FourGoldenSignals extends Base<Props> {
       saturationLabels: Joi.array().items(Joi.string()).min(1),
       trafficName: Joi.string(),
       trafficHelp: Joi.string(),
-      trafficLabels: Joi.array().items(Joi.string()).min(1)
+      trafficLabels: Joi.array().items(Joi.string()).min(1),
+      collectDefaultMetrics: Joi.boolean()
     })
   }
 }

--- a/src/frameworks/RED.ts
+++ b/src/frameworks/RED.ts
@@ -6,6 +6,7 @@ type Props = {
   durationLabels: string[]
   requestType: string
   requestLabels: string[]
+  collectDefaultMetrics?: boolean
 }
 
 class RED extends Base<Props> {
@@ -24,7 +25,10 @@ class RED extends Base<Props> {
     this.requestType = params.requestType
 
     this.validate(params)
-    defaultMetrics()
+
+    if (params.collectDefaultMetrics) {
+      defaultMetrics()
+    }
 
     this.duration = histogram({
       name: `${this.requestType}_duration_seconds`,
@@ -49,7 +53,8 @@ class RED extends Base<Props> {
     return Joi.object({
       durationLabels: Joi.array().items(Joi.string()).min(1),
       requestType: Joi.string(),
-      requestLabels: Joi.array().items(Joi.string()).min(1)
+      requestLabels: Joi.array().items(Joi.string()).min(1),
+      collectDefaultMetrics: Joi.boolean()
     })
   }
 }

--- a/src/frameworks/USE.ts
+++ b/src/frameworks/USE.ts
@@ -9,6 +9,7 @@ type Props = {
   utilizationName: string
   utilizationHelp: string
   utilizationLabels: string[]
+  collectDefaultMetrics?: boolean
 }
 
 class USE extends Base<Props> {
@@ -33,7 +34,10 @@ class USE extends Base<Props> {
     this.utilizationLabels = params.utilizationLabels
 
     this.validate(params)
-    defaultMetrics()
+
+    if (params.collectDefaultMetrics) {
+      defaultMetrics()
+    }
 
     this.errors = counter({
       name: 'errors_total',
@@ -61,7 +65,8 @@ class USE extends Base<Props> {
       saturationLabels: Joi.array().items(Joi.string()).min(1),
       utilizationName: Joi.string(),
       utilizationHelp: Joi.string(),
-      utilizationLabels: Joi.array().items(Joi.string()).min(1)
+      utilizationLabels: Joi.array().items(Joi.string()).min(1),
+      collectDefaultMetrics: Joi.boolean()
     })
   }
 }

--- a/src/frameworks/__tests__/FourGoldenSignals.test.ts
+++ b/src/frameworks/__tests__/FourGoldenSignals.test.ts
@@ -9,7 +9,8 @@ const params = ({
   trafficLabels = ['label3', 'label4'],
   saturationName = 'saturation',
   saturationHelp = 'saturation metric',
-  saturationLabels = ['label5', 'label6']
+  saturationLabels = ['label5', 'label6'],
+  collectDefaultMetrics = true
 }) => {
   return {
     latencyName,
@@ -20,7 +21,8 @@ const params = ({
     trafficLabels,
     saturationName,
     saturationHelp,
-    saturationLabels
+    saturationLabels,
+    collectDefaultMetrics
   }
 }
 
@@ -33,24 +35,18 @@ describe('FourGoldenSignals', () => {
   })
   describe('validation', () => {
     describe('when empty values are passed', () => {
-      test.each(Object.entries(params({})))(
-        'given %p and and empty string as arguments, throws an error',
-        (a, b) => {
-          expect(() => {
-            new FourGoldenSignals(params({ [a]: '' }))
-          }).toThrow(Error)
-        }
-      )
+      test.each(Object.entries(params({})))('given %p and and empty string as arguments, throws an error', (a, b) => {
+        expect(() => {
+          new FourGoldenSignals(params({ [a]: '' }))
+        }).toThrow(Error)
+      })
     })
     describe('when unexpected type of value is passed', () => {
-      test.each(Object.entries(params({})))(
-        'given %p and 0 as arguments, throws an error',
-        (a, b) => {
-          expect(() => {
-            new FourGoldenSignals(params({ [a]: 0 }))
-          }).toThrow(Error)
-        }
-      )
+      test.each(Object.entries(params({})))('given %p and 0 as arguments, throws an error', (a, b) => {
+        expect(() => {
+          new FourGoldenSignals(params({ [a]: 0 }))
+        }).toThrow(Error)
+      })
     })
     describe('when arrays of unexpected length are passed', () => {
       it('throws an error for latencyLabels', () => {
@@ -92,4 +88,3 @@ describe('FourGoldenSignals', () => {
     })
   })
 })
-

--- a/src/frameworks/__tests__/RED.test.ts
+++ b/src/frameworks/__tests__/RED.test.ts
@@ -1,14 +1,16 @@
 import RED from '../RED'
 
 const params = ({
-  durationLabels = ['label1','label2'],
+  durationLabels = ['label1', 'label2'],
   requestType = 'api_post',
-  requestLabels = ['label3', 'label4']
+  requestLabels = ['label3', 'label4'],
+  collectDefaultMetrics = true
 }) => {
   return {
     durationLabels,
     requestType,
-    requestLabels
+    requestLabels,
+    collectDefaultMetrics
   }
 }
 
@@ -20,24 +22,18 @@ describe('RED', () => {
     })
   })
   describe('when empty values are passed', () => {
-    test.each(Object.entries(params({})))(
-      'given %p and and empty string as arguments, throws an error',
-      (a, b) => {
-        expect(() => {
-          new RED(params({ [a]: '' }))
-        }).toThrow(Error)
-      }
-    )
+    test.each(Object.entries(params({})))('given %p and and empty string as arguments, throws an error', (a, b) => {
+      expect(() => {
+        new RED(params({ [a]: '' }))
+      }).toThrow(Error)
+    })
   })
   describe('when unexpected type of value is passed', () => {
-    test.each(Object.entries(params({})))(
-      'given %p and 0 as arguments, throws an error',
-      (a, b) => {
-        expect(() => {
-          new RED(params({ [a]: 0 }))
-        }).toThrow(Error)
-      }
-    )
+    test.each(Object.entries(params({})))('given %p and 0 as arguments, throws an error', (a, b) => {
+      expect(() => {
+        new RED(params({ [a]: 0 }))
+      }).toThrow(Error)
+    })
   })
   describe('when arrays of unexpected length are passed', () => {
     it('throws an error for durationLabels', () => {

--- a/src/frameworks/__tests__/USE.test.ts
+++ b/src/frameworks/__tests__/USE.test.ts
@@ -7,6 +7,7 @@ const params = ({
   utilizationName = 'utilization',
   utilizationHelp = 'utilization metric',
   utilizationLabels = ['label1', 'label2'],
+  collectDefaultMetrics = true
 }) => {
   return {
     saturationName,
@@ -14,7 +15,8 @@ const params = ({
     saturationLabels,
     utilizationName,
     utilizationHelp,
-    utilizationLabels
+    utilizationLabels,
+    collectDefaultMetrics
   }
 }
 
@@ -26,24 +28,18 @@ describe('USE', () => {
     })
   })
   describe('when empty values are passed', () => {
-    test.each(Object.entries(params({})))(
-      'given %p and and empty string as arguments, throws an error',
-      (a, b) => {
-        expect(() => {
-          new USE(params({ [a]: '' }))
-        }).toThrow(Error)
-      }
-    )
+    test.each(Object.entries(params({})))('given %p and and empty string as arguments, throws an error', (a, b) => {
+      expect(() => {
+        new USE(params({ [a]: '' }))
+      }).toThrow(Error)
+    })
   })
   describe('when unexpected type of value is passed', () => {
-    test.each(Object.entries(params({})))(
-      'given %p and 0 as arguments, throws an error',
-      (a, b) => {
-        expect(() => {
-          new USE(params({ [a]: 0 }))
-        }).toThrow(Error)
-      }
-    )
+    test.each(Object.entries(params({})))('given %p and 0 as arguments, throws an error', (a, b) => {
+      expect(() => {
+        new USE(params({ [a]: 0 }))
+      }).toThrow(Error)
+    })
   })
   describe('when arrays of unexpected length are passed', () => {
     it('throws an error for saturationLabels', () => {


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change
Add ability to disable default metrics
The DefaultMetric can be either collected or disabled based on the value of the collectDefaultMetrics parameter. By default disabled.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
