### PR TITLE
fix(component): preventing registering metrics twice

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,9 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ['./tsconfig.json'],
   },
+  globals: {
+    jest: true
+  },
   plugins: ['@typescript-eslint', 'node', 'prettier'],
   root: true,
   rules: {

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -4,7 +4,9 @@ jest.mock('prom-client', () => ({
   Gauge: jest.fn(),
   Histogram: jest.fn(),
   register: {
-    metrics: jest.fn()
+    metrics: jest.fn(),
+    getSingleMetric: jest.fn(),
+    contentType: 'contentType'
   },
   Summary: jest.fn()
 }))

--- a/src/__tests__/metrics.test.ts
+++ b/src/__tests__/metrics.test.ts
@@ -1,5 +1,5 @@
-import { collect, counter, defaultMetrics, gauge, histogram, summary } from '../metrics'
-import promClient, { collectDefaultMetrics, Counter, Histogram, Gauge, Summary } from 'prom-client'
+import { collect, counter, defaultMetrics, gauge, histogram, summary, getContentType } from '../metrics'
+import promClient, { collectDefaultMetrics, Counter, Histogram, Gauge, Summary, register } from 'prom-client'
 
 const params = {
   name: 'test name',
@@ -8,21 +8,52 @@ const params = {
 }
 
 describe('metrics', () => {
-  test.each([[counter, Counter], [histogram, Histogram], [gauge, Gauge], [summary, Summary]])(
-    '%p passes correct params to %p',
-    (a, b) => {
-      a(params)
-      expect(b).toHaveBeenCalledWith(params)
-    }
-  )
+  test.each([
+    [counter, Counter],
+    [histogram, Histogram],
+    [gauge, Gauge],
+    [summary, Summary]
+  ])('%p passes correct params to %p', (a, b) => {
+    // @ts-expect-error (ts2339)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    register.getSingleMetric.mockReturnValue(undefined)
+    a(params)
+    expect(b).toHaveBeenCalledWith(params)
+  })
 
-  it('collects metrics', () => {
-    collect()
+  test.each([[counter], [histogram], [gauge], [summary]])('prevents registration of duplicate metrics, method=%p', (method) => {
+    // @ts-expect-error (ts2339)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    register.getSingleMetric.mockReturnValue(undefined)
+    const result1 = method(params)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(register.getSingleMetric).toHaveBeenCalledTimes(1)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(register.getSingleMetric).toHaveBeenLastCalledWith(params.name)
+
+    // @ts-expect-error (ts2339)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    register.getSingleMetric.mockReturnValue(result1)
+    const result2 = method(params)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(register.getSingleMetric).toHaveBeenCalledTimes(2)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(register.getSingleMetric).toHaveBeenLastCalledWith(params.name)
+    expect(result1).toEqual(result2)
+  })
+
+  it('collects metrics', async () => {
+    await collect()
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(promClient.register.metrics).toHaveBeenCalled()
   })
 
-  it('collects default metrics', async () => {
-    await defaultMetrics()
+  it('collects default metrics', () => {
+    defaultMetrics()
     expect(collectDefaultMetrics).toHaveBeenCalled()
+  })
+
+  it('get content type', () => {
+    expect(getContentType()).toEqual('contentType')
   })
 })

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,4 +1,4 @@
-import promClient, { collectDefaultMetrics, Counter, Gauge, Histogram, Summary } from 'prom-client'
+import promClient, { collectDefaultMetrics, Counter, Gauge, Histogram, Summary, register } from 'prom-client'
 
 interface Metrics {
   name: string
@@ -6,11 +6,19 @@ interface Metrics {
   labelNames: string[]
 }
 
+function getContentType(): string {
+  return promClient.register.contentType
+}
+
 function collect(): Promise<string> {
   return promClient.register.metrics()
 }
 
 function counter(params: Metrics): Counter {
+  const result = register.getSingleMetric(params.name) as Counter | undefined
+  if (result) {
+    return result
+  }
   return new Counter(params)
 }
 
@@ -19,22 +27,27 @@ function defaultMetrics(): void {
 }
 
 function gauge(params: Metrics): Gauge {
+  const result = register.getSingleMetric(params.name) as Gauge | undefined
+  if (result) {
+    return result
+  }
   return new Gauge(params)
 }
 
 function histogram(params: Metrics): Histogram {
+  const result = register.getSingleMetric(params.name) as Histogram | undefined
+  if (result) {
+    return result
+  }
   return new Histogram(params)
 }
 
 function summary(params: Metrics): Summary {
+  const result = register.getSingleMetric(params.name) as Summary | undefined
+  if (result) {
+    return result
+  }
   return new Summary(params)
 }
 
-export {
-  collect,
-  counter,
-  defaultMetrics,
-  gauge,
-  histogram,
-  summary
-}
+export { getContentType, collect, counter, defaultMetrics, gauge, histogram, summary }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,6 +3,7 @@
   "exclude": [
     "__tests__/**/*.test.ts",
     "src/__tests__/**/*.test.ts",
-    "src/frameworks/__tests__/**/*.test.ts"
+    "src/frameworks/__tests__/**/*.test.ts",
+    "setupTests.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts", "setupTests.ts"]
 }


### PR DESCRIPTION
### Description of change
- Updated node-key-metrics to check if metrics are already registered in the prom-client global registry before registry them. An exception `A metric with the name x has already been registered.` can happen for example when using Next.js modules loads asynchronously, and more than one loaded in a short space of time
- Exposed `getContentType` from `prom-client`
- Fixed lint issues
- Added tests