### PR TITLE
fix(component): exporting getContentType in index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,4 @@
 export { default as FourGoldenSignals } from './frameworks/FourGoldenSignals'
 export { default as RED } from './frameworks/RED'
 export { default as USE } from './frameworks/USE'
-export {
-  collect,
-  counter,
-  defaultMetrics,
-  gauge,
-  histogram,
-  summary
-} from './metrics'
+export { getContentType, collect, counter, defaultMetrics, gauge, histogram, summary } from './metrics'


### PR DESCRIPTION
Exporting getContentType in index.ts, otherwise it won't be possible to use it

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
